### PR TITLE
Enable optional compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,6 @@ dist: clean
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist
+
+watch: .venv
+	.venv/bin/watchmedo shell-command --drop -c 'clear && make lint && make mypy && .venv/bin/pytest -x' $(CODE_LOCATIONS)

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,6 @@ dist: clean
 	ls -l dist
 
 watch: .venv
-	.venv/bin/watchmedo shell-command --drop -c 'clear && make lint && make mypy && .venv/bin/pytest -x' $(CODE_LOCATIONS)
+	@clear
+	@make test || true
+	@.venv/bin/watchmedo shell-command --drop -c 'clear && make test'

--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,20 @@ Install the package with pip:
 
     pip install proj
 
-Then, tell ``proj`` where your archive directory is, by adding a line to your ``.bashrc`` or ``.zshrc`` file:
+Then, tell ``proj`` where your archive directory is, by creating a ``~/.proj.yml`` file
 
-.. code:: console
+.. code::
 
-    export PROJ_ARCHIVE=~/Archive
+    archive_dir: _archive
+
+You can enable compression for archives by adding more directives to the YAML file:
+
+.. code::
+
+    compression: true
+    compression_format: bztar
+
+The supported formats are: ``tar``, ``gztar``, ``bztar`` and ``zip``.
 
 Usage
 -----

--- a/defaults.mk
+++ b/defaults.mk
@@ -30,7 +30,7 @@ unittest-default: .venv
 	@echo "==> Running tests..."
 	@PYTHONPATH=. .venv/bin/pytest $(CODE_LOCATIONS) --cov-report term-missing:skip-covered --cov $(CODE_LOCATIONS) --no-cov-on-fail --cov-fail-under=$(COVERAGE_LIMIT) -W ignore::DeprecationWarning -vv
 
-.venv: test_requirements.txt
+.venv: requirements.txt test_requirements.txt
 	@echo '==> Updating the virtualenv...'
 	test -d .venv || python3 -m venv .venv
 	# build wheels when developing locally

--- a/proj/__init__.py
+++ b/proj/__init__.py
@@ -165,7 +165,16 @@ def list(pattern: List[str]) -> None:
     offset = len(archive_dir) + 1
     for suffix in globs:
         glob_pattern = os.path.join(archive_dir, "*", "*", suffix)
-        match_set = set(f[offset:] for f in glob.glob(glob_pattern))
+
+        match_set = set()
+        for full_filename in glob.glob(glob_pattern):
+            if full_filename.endswith(COMPRESS_EXT):
+                base = full_filename[offset : -len(COMPRESS_EXT)]
+            else:
+                base = full_filename[offset:]
+
+            match_set.add(base)
+
         match_sets.append(match_set)
 
     final_set = reduce(lambda x, y: x.intersection(y), match_sets)

--- a/proj/__init__.py
+++ b/proj/__init__.py
@@ -10,36 +10,14 @@ __author__ = "Lars Yencken"
 __email__ = "lars@yencken.org"
 __version__ = "0.2.0"
 
-import glob
 import os
-import shutil
-import sys
-from functools import reduce
-import datetime as dt
-from typing import NoReturn, Tuple, List, Iterator
+from typing import List
 
-import arrow
 import click
 
-PROJ_ARCHIVE = os.environ.get("PROJ_ARCHIVE")
-
-COMPRESS_FORMAT = "bztar"
-COMPRESS_EXT = ".tar.bz2"
-
-
-def bail(message: str) -> NoReturn:
-    click.echo(message, err=True)
-    sys.exit(1)
-
-
-def get_archive_dir() -> str:
-    if PROJ_ARCHIVE is None:
-        bail("please set PROJ_ARCHIVE to your archive's location")
-
-    if not os.path.isdir(PROJ_ARCHIVE):
-        bail("archive directory does not exist: " + PROJ_ARCHIVE)
-
-    return PROJ_ARCHIVE
+from proj.configfile import Config, NoConfigError
+from proj import logic
+from proj.ui import bail
 
 
 @click.group()
@@ -61,165 +39,49 @@ def main():
 @click.command()
 @click.argument("folder", nargs=-1)
 @click.option("-n", "--dry-run", is_flag=True, help="Don't make any changes")
-@click.option("--no-compress", is_flag=True, help="Do not compress the folder")
-def archive(folder: List[str], dry_run: bool = False, no_compress: bool = False):
+def archive(folder: List[str], dry_run: bool = False):
     "Move an active project to the archive."
-    # error handling on archive_dir already done in main()
+    config = _get_config()
 
     for f in folder:
         if not os.path.exists(f):
             bail("folder does not exist: " + f)
 
-    archive_dir = get_archive_dir()
-    _archive_safe(folder, archive_dir, dry_run=dry_run, compress=not no_compress)
-
-
-def _last_modified(folder: str) -> dt.datetime:
-    try:
-        return max(
-            _time_modified(f) for f in _iter_files(folder) if not os.path.islink(f)
-        )
-
-    except ValueError:
-        bail("no files in folder: " + folder)
-
-
-def _iter_files(folder: str) -> Iterator[str]:
-    if os.path.isdir(folder):
-        for dirname, subdirs, filenames in os.walk(folder):
-            for basename in filenames:
-                filename = os.path.join(dirname, basename)
-                yield filename
-    else:
-        # it's actually just a file
-        yield folder
-
-
-def _time_modified(filename: str) -> arrow.Arrow:
-    return arrow.get(os.stat(filename).st_mtime)
-
-
-def _to_quarter(t: dt.datetime) -> Tuple[str, str]:
-    return str(t.year), "q" + str(1 + (t.month - 1) // 3)
-
-
-def _archive_safe(
-    folders: List[str], archive_dir: str, dry_run: bool = False, compress: bool = False
-) -> None:
-    for folder in folders:
-        t = _last_modified(folder)
-        year, quarter = _to_quarter(t)
-        dest_dir = os.path.join(archive_dir, year, quarter, os.path.basename(folder))
-
-        print(folder, "-->", dest_dir)
-        if not dry_run:
-            if compress and os.path.isdir(folder):
-                _compress_and_archive(folder, dest_dir)
-            else:
-                _archive_folder(folder, dest_dir)
-
-
-def _archive_folder(folder, dest_dir):
-    parent_dir = os.path.dirname(dest_dir)
-    _mkdir(parent_dir)
-    shutil.move(folder, dest_dir)
-
-
-def _compress_and_archive(src_folder, dst_folder):
-    parent_dir = os.path.dirname(dst_folder)
-    _mkdir(parent_dir)
-
-    try:
-        shutil.make_archive(dst_folder, COMPRESS_FORMAT, src_folder)
-    except Exception as e:
-        os.unlink(dst_folder + COMPRESS_EXT)
-        raise e
-
-    shutil.rmtree(src_folder)
-
-
-def _mkdir(p: str) -> None:
-    "The equivalent of 'mkdir -p' in shell."
-    isdir = os.path.isdir
-
-    stack = [os.path.abspath(p)]
-    while not isdir(stack[-1]):
-        parent_dir = os.path.dirname(stack[-1])
-        stack.append(parent_dir)
-
-    while stack:
-        p = stack.pop()
-        if not isdir(p):
-            os.mkdir(p)
+        logic.archive(f, config, dry_run=dry_run)
 
 
 @click.command()
 @click.argument("pattern", nargs=-1)
 def list(pattern: List[str]) -> None:
     "List the contents of the archive directory."
-    # strategy: pick the intersection of all the patterns the user provides
-    globs = ["*{0}*".format(p) for p in pattern] + ["*"]
-    archive_dir = get_archive_dir()
+    config = _get_config()
 
-    match_sets = []
-    offset = len(archive_dir) + 1
-    for suffix in globs:
-        glob_pattern = os.path.join(archive_dir, "*", "*", suffix)
+    projects = logic.list_projects(pattern, config)
 
-        match_set = set()
-        for full_filename in glob.glob(glob_pattern):
-            if full_filename.endswith(COMPRESS_EXT):
-                base = full_filename[offset : -len(COMPRESS_EXT)]
-            else:
-                base = full_filename[offset:]
-
-            match_set.add(base)
-
-        match_sets.append(match_set)
-
-    final_set = reduce(lambda x, y: x.intersection(y), match_sets)
-
-    for m in sorted(final_set):
+    for m in projects:
         print(m)
 
 
 @click.command()
 @click.argument("folder")
 def restore(folder: str) -> None:
-    "Restore a project from the archive."
-    if os.path.isdir(folder):
+    "Restore a project from the archive into the current directory."
+    config = _get_config()
+
+    if os.path.exists(folder):
         bail("a folder of the same name already exists!")
 
-    source = _find_restore_match(folder)
-
-    if source.endswith(COMPRESS_EXT):
-        nice_source = source[: -len(COMPRESS_EXT)]
-        print(nice_source, "-->", folder)
-        shutil.unpack_archive(source, "./" + folder)
-        os.unlink(source)
-    else:
-        print(source, "-->", folder)
-        shutil.move(source, ".")
+    logic.restore(folder, config)
 
 
-def _find_restore_match(folder):
-    archive_dir = get_archive_dir()
-    pattern = os.path.join(archive_dir, "*", "*", folder)
-    matches = glob.glob(pattern)
-    if not matches:
-        # try compressed
-        pattern = os.path.join(archive_dir, "*", "*", folder + COMPRESS_EXT)
-        matches = glob.glob(pattern)
+def _get_config() -> Config:
+    try:
+        config = Config.autoload()
 
-        if not matches:
-            bail("no project matches: " + folder)
+    except NoConfigError:
+        bail("No config file found, run proj init")
 
-    if len(matches) > 1:
-        print("Warning: multiple matches, picking the most recent", file=sys.stderr)
-
-    source = sorted(matches)[-1]
-
-    return source
+    return config
 
 
 main.add_command(archive)

--- a/proj/__init__.py
+++ b/proj/__init__.py
@@ -79,7 +79,10 @@ def _get_config() -> Config:
         config = Config.autoload()
 
     except NoConfigError:
-        bail("No config file found, run proj init")
+        bail(
+            "No config file found at ~/.proj.yml -- please set one up\n"
+            "See https://github.com/larsyencken/proj/ for an example"
+        )
 
     return config
 

--- a/proj/__init__.py
+++ b/proj/__init__.py
@@ -23,6 +23,9 @@ import click
 
 PROJ_ARCHIVE = os.environ.get("PROJ_ARCHIVE")
 
+COMPRESS_FORMAT = "bztar"
+COMPRESS_EXT = ".tar.bz2"
+
 
 def bail(message: str) -> NoReturn:
     click.echo(message, err=True)
@@ -58,7 +61,8 @@ def main():
 @click.command()
 @click.argument("folder", nargs=-1)
 @click.option("-n", "--dry-run", is_flag=True, help="Don't make any changes")
-def archive(folder: List[str], dry_run: bool = False):
+@click.option("--no-compress", is_flag=True, help="Do not compress the folder")
+def archive(folder: List[str], dry_run: bool = False, no_compress: bool = False):
     "Move an active project to the archive."
     # error handling on archive_dir already done in main()
 
@@ -67,7 +71,7 @@ def archive(folder: List[str], dry_run: bool = False):
             bail("folder does not exist: " + f)
 
     archive_dir = get_archive_dir()
-    _archive_safe(folder, archive_dir, dry_run=dry_run)
+    _archive_safe(folder, archive_dir, dry_run=dry_run, compress=not no_compress)
 
 
 def _last_modified(folder: str) -> dt.datetime:
@@ -99,7 +103,9 @@ def _to_quarter(t: dt.datetime) -> Tuple[str, str]:
     return str(t.year), "q" + str(1 + (t.month - 1) // 3)
 
 
-def _archive_safe(folders: List[str], archive_dir: str, dry_run: bool = False) -> None:
+def _archive_safe(
+    folders: List[str], archive_dir: str, dry_run: bool = False, compress: bool = False
+) -> None:
     for folder in folders:
         t = _last_modified(folder)
         year, quarter = _to_quarter(t)
@@ -107,9 +113,29 @@ def _archive_safe(folders: List[str], archive_dir: str, dry_run: bool = False) -
 
         print(folder, "-->", dest_dir)
         if not dry_run:
-            parent_dir = os.path.dirname(dest_dir)
-            _mkdir(parent_dir)
-            shutil.move(folder, dest_dir)
+            if compress:
+                _compress_and_archive(folder, dest_dir)
+            else:
+                _archive_folder(folder, dest_dir)
+
+
+def _archive_folder(folder, dest_dir):
+    parent_dir = os.path.dirname(dest_dir)
+    _mkdir(parent_dir)
+    shutil.move(folder, dest_dir)
+
+
+def _compress_and_archive(src_folder, dst_folder):
+    parent_dir = os.path.dirname(dst_folder)
+    _mkdir(parent_dir)
+
+    try:
+        shutil.make_archive(dst_folder, COMPRESS_FORMAT, src_folder)
+    except Exception as e:
+        shutil.rm(dst_folder + COMPRESS_EXT)
+        raise e
+
+    shutil.rmtree(src_folder)
 
 
 def _mkdir(p: str) -> None:
@@ -155,18 +181,36 @@ def restore(folder: str) -> None:
     if os.path.isdir(folder):
         bail("a folder of the same name already exists!")
 
+    source = _find_restore_match(folder)
+
+    if source.endswith(COMPRESS_EXT):
+        nice_source = source[: -len(COMPRESS_EXT)]
+        print(nice_source, "-->", folder)
+        shutil.unpack_archive(source, "./" + folder)
+        os.unlink(source)
+    else:
+        print(source, "-->", folder)
+        shutil.move(source, ".")
+
+
+def _find_restore_match(folder):
     archive_dir = get_archive_dir()
     pattern = os.path.join(archive_dir, "*", "*", folder)
     matches = glob.glob(pattern)
     if not matches:
-        bail("no project matches: " + folder)
+        # try compressed
+        pattern = os.path.join(archive_dir, "*", "*", folder + COMPRESS_EXT)
+        matches = glob.glob(pattern)
+
+        if not matches:
+            bail("no project matches: " + folder)
 
     if len(matches) > 1:
         print("Warning: multiple matches, picking the most recent", file=sys.stderr)
 
     source = sorted(matches)[-1]
-    print(source, "-->", folder)
-    shutil.move(source, ".")
+
+    return source
 
 
 main.add_command(archive)

--- a/proj/__init__.py
+++ b/proj/__init__.py
@@ -132,7 +132,7 @@ def _compress_and_archive(src_folder, dst_folder):
     try:
         shutil.make_archive(dst_folder, COMPRESS_FORMAT, src_folder)
     except Exception as e:
-        shutil.rm(dst_folder + COMPRESS_EXT)
+        os.unlink(dst_folder + COMPRESS_EXT)
         raise e
 
     shutil.rmtree(src_folder)

--- a/proj/__init__.py
+++ b/proj/__init__.py
@@ -113,7 +113,7 @@ def _archive_safe(
 
         print(folder, "-->", dest_dir)
         if not dry_run:
-            if compress:
+            if compress and os.path.isdir(folder):
                 _compress_and_archive(folder, dest_dir)
             else:
                 _archive_folder(folder, dest_dir)

--- a/proj/configfile.py
+++ b/proj/configfile.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+#  config.py
+#  proj
+#
+
+from typing import Optional
+from dataclasses import dataclass
+from os import path
+
+import yaml
+
+from proj import fs
+
+
+DEFAULT_CONFIG_PATH = "~/.proj.yml"
+
+
+@dataclass
+class Config:
+    archive_dir: str = "_archive"
+    compression: bool = False
+    compression_format: Optional[str] = None
+
+    @classmethod
+    def autoload(cls) -> "Config":
+        filename = cls._get_config_file()
+        return cls.load(filename)
+
+    @classmethod
+    def load(cls, filename: str) -> "Config":
+        with open(filename) as istream:
+            doc = yaml.safe_load(istream)
+            return cls(**doc)
+
+    def save(self, filename: str) -> None:
+        record = {
+            "archive_dir": self.archive_dir,
+            "compression": self.compression,
+            "compression_format": self.compression_format,
+        }
+        with open(filename, "w") as ostream:
+            yaml.dump(record, ostream)
+
+    @staticmethod
+    def _get_config_file() -> str:
+        filename = path.expanduser(DEFAULT_CONFIG_PATH)
+        if not path.exists(filename):
+            raise NoConfigError()
+
+        return filename
+
+    @property
+    def compression_ext(self) -> str:
+        if not self.compression_format:
+            raise KeyError("no compression format selected")
+
+        return fs.SUPPORTED_FORMATS[self.compression_format]
+
+
+class NoConfigError(Exception):
+    pass

--- a/proj/exceptions.py
+++ b/proj/exceptions.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+#  exceptions.py
+#  proj
+#
+
+
+class CommandError(Exception):
+    "An expected error type with a helpful message for the user."
+    pass

--- a/proj/fs.py
+++ b/proj/fs.py
@@ -16,7 +16,12 @@ import arrow
 from proj.exceptions import CommandError
 
 
-SUPPORTED_FORMATS = {"bztar": ".tar.bz2", "gztar": ".tar.gz", "zip": ".zip"}
+SUPPORTED_FORMATS = {
+    "bztar": ".tar.bz2",
+    "gztar": ".tar.gz",
+    "zip": ".zip",
+    "tar": ".tar",
+}
 
 
 def mkdir(p: str) -> None:

--- a/proj/fs.py
+++ b/proj/fs.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+#  fs.py
+#  proj
+#
+
+"""
+Filesystem operations.
+"""
+
+import os
+from typing import Iterator
+
+import arrow
+
+from proj.exceptions import CommandError
+
+
+SUPPORTED_FORMATS = {"bztar": ".tar.bz2", "gztar": ".tar.gz", "zip": ".zip"}
+
+
+def mkdir(p: str) -> None:
+    "The equivalent of 'mkdir -p' in shell."
+    isdir = os.path.isdir
+
+    stack = [os.path.abspath(p)]
+    while not isdir(stack[-1]):
+        parent_dir = os.path.dirname(stack[-1])
+        stack.append(parent_dir)
+
+    while stack:
+        p = stack.pop()
+        if not isdir(p):
+            os.mkdir(p)
+
+
+def is_compressed(path: str) -> bool:
+    return any(path.endswith(ext) for ext in SUPPORTED_FORMATS.values())
+
+
+def trim_archive_extension(path: str) -> str:
+    "Remove any extension from the path due to compression."
+    for ext in SUPPORTED_FORMATS.values():
+        if path.endswith(ext):
+            return path[: -len(ext)]
+
+    return path
+
+
+def last_modified(file_or_folder: str) -> arrow.Arrow:
+    "Work out when the most recent file in a folder was modified."
+    try:
+        return max(
+            mtime(f) for f in iter_files(file_or_folder) if not os.path.islink(f)
+        )
+
+    except ValueError:
+        raise CommandError(f"no files in folder: {file_or_folder}")
+
+
+def iter_files(file_or_folder: str) -> Iterator[str]:
+    "Walk the given path and iterate over all files within it."
+    if os.path.isdir(file_or_folder):
+        for dirname, subdirs, filenames in os.walk(file_or_folder):
+            for basename in filenames:
+                filename = os.path.join(dirname, basename)
+                yield filename
+    else:
+        # it's actually just a file
+        yield file_or_folder
+
+
+def mtime(filename: str) -> arrow.Arrow:
+    return arrow.get(os.stat(filename).st_mtime)

--- a/proj/fs.py
+++ b/proj/fs.py
@@ -72,3 +72,8 @@ def iter_files(file_or_folder: str) -> Iterator[str]:
 
 def mtime(filename: str) -> arrow.Arrow:
     return arrow.get(os.stat(filename).st_mtime)
+
+
+def touch(filename: str) -> None:
+    with open(filename, "a"):
+        pass

--- a/proj/logic.py
+++ b/proj/logic.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+#  logic.py
+#  proj
+#
+
+"""
+High level operations for proj.
+"""
+
+import os
+from typing import List, Tuple
+import shutil
+import glob
+import datetime as dt
+from functools import reduce
+
+import click
+
+from proj.configfile import Config
+from proj import fs
+from proj.exceptions import CommandError
+
+
+def archive(src_path: str, config: Config, dry_run: bool = False) -> None:
+    "Take a folder from the current directory and move it to the archive."
+    if not os.path.exists(src_path):
+        raise CommandError(f"no such file or folder: {src_path}")
+
+    dest_path = _archive_path(src_path, config)
+
+    print(src_path, "-->", dest_path)
+    if not dry_run:
+        _archive_project(src_path, dest_path, config)
+
+
+def restore(dest_path: str, config: Config) -> None:
+    "Take a project folder out of the archive and place it in the current working directory."
+    if os.path.exists(dest_path):
+        raise CommandError(f"file or directory already exists at: {dest_path}")
+
+    source = _find_restore_match(dest_path, config.archive_dir)
+
+    if fs.is_compressed(source):
+        nice_source = fs.trim_archive_extension(source)
+        print(nice_source, "-->", dest_path)
+
+        shutil.unpack_archive(source, "./{folder}")
+        os.unlink(source)
+    else:
+        print(source, "-->", dest_path)
+        shutil.move(source, ".")
+
+
+def list_projects(patterns: List[str], config: Config) -> List[str]:
+    # strategy: pick the intersection of all the patterns the user provides
+    globs = ["*{0}*".format(p) for p in patterns] + ["*"]
+
+    match_sets = []
+    offset = len(config.archive_dir) + 1
+    for suffix in globs:
+        glob_pattern = f"{config.archive_dir}/*/*/{suffix}"
+
+        match_set = set()
+        for full_filename in glob.glob(glob_pattern):
+            tail_filename = full_filename[offset:]
+            base = fs.trim_archive_extension(tail_filename)
+            match_set.add(base)
+
+        match_sets.append(match_set)
+
+    final_set = reduce(lambda x, y: x.intersection(y), match_sets)
+
+    return sorted(final_set)
+
+
+def _archive_path(src_path: str, config: Config) -> str:
+    "Find where to archive the path to based on when it was last changed."
+    t = fs.last_modified(src_path)
+    year, quarter = _to_quarter(t)
+    return os.path.join(config.archive_dir, year, quarter, os.path.basename(src_path))
+
+
+def _archive_project(src_path: str, dest_path: str, config: Config) -> None:
+    parent_dir = os.path.dirname(dest_path)
+    fs.mkdir(parent_dir)
+
+    if config.compression:
+        compression_format: str = config.compression_format  # type: ignore
+        _archive_compressed(
+            src_path, dest_path, compression_format, config.compression_ext
+        )
+    else:
+        shutil.move(src_path, dest_path)
+
+
+def _archive_compressed(
+    src_path: str, dest_path: str, compression_format: str, compression_ext: str
+) -> None:
+    "Compress the folder into an file in the archive, then remove the original"
+    dest_filename = dest_path + compression_ext
+
+    try:
+        shutil.make_archive(dest_path, compression_format, src_path)
+
+    except Exception as e:
+        # remove the partially compressed file
+        if os.path.exists(dest_filename):
+            os.unlink(dest_filename)
+
+        raise e
+
+    shutil.rmtree(src_path)
+
+
+def _find_restore_match(proj_name: str, archive_dir: str) -> str:
+    base_pattern = os.path.join(archive_dir, "*", "*", proj_name)
+
+    patterns = [base_pattern]
+    for ext in fs.SUPPORTED_FORMATS.values():
+        patterns.append(base_pattern + ext)
+
+    matches = []
+    for pattern in patterns:
+        matches.extend(glob.glob(pattern))
+
+    if not matches:
+        raise CommandError(f"no project matches: {proj_name}")
+
+    if len(matches) > 1:
+        click.echo("Warning: multiple matches, picking the most recent", err=True)
+
+    source = sorted(matches)[-1]
+
+    return source
+
+
+def _to_quarter(t: dt.datetime) -> Tuple[str, str]:
+    return str(t.year), "q" + str(1 + (t.month - 1) // 3)

--- a/proj/logic.py
+++ b/proj/logic.py
@@ -45,7 +45,7 @@ def restore(dest_path: str, config: Config) -> None:
         nice_source = fs.trim_archive_extension(source)
         print(nice_source, "-->", dest_path)
 
-        shutil.unpack_archive(source, "./{folder}")
+        shutil.unpack_archive(source, ".")
         os.unlink(source)
     else:
         print(source, "-->", dest_path)
@@ -101,7 +101,7 @@ def _archive_compressed(
     dest_filename = dest_path + compression_ext
 
     try:
-        shutil.make_archive(dest_path, compression_format, src_path)
+        shutil.make_archive(dest_path, compression_format, ".", src_path)
 
     except Exception as e:
         # remove the partially compressed file

--- a/proj/ui.py
+++ b/proj/ui.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+#  ui.py
+#  proj
+#
+
+import sys
+from typing import NoReturn
+
+import click
+
+
+def bail(message: str) -> NoReturn:
+    click.echo(message, err=True)
+    sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 arrow==0.15.6
 click==7.1.2
 wheel==0.34.2
+PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,7 @@ universal = 1
 
 [flake8]
 max-line-length = 88
-extend-ignore = E203
-ignore = E501
+ignore = E203, E501
 
 [coverage:report]
 show_missing = True

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,9 @@ black
 pytest
 flake8
 mypy
-pytest-cov
+watchdog
+argh
+
+# Workaround for chdir issue
+# https://github.com/pytest-dev/pytest-cov/issues/306
+pytest-cov==2.5.1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+#  test_config.py
+#  proj
+#
+
+"""
+"""
+
+from tempfile import NamedTemporaryFile
+
+from proj import Config
+
+
+def test_read_write_config():
+    with NamedTemporaryFile() as f:
+        filename = f.name
+
+        config = Config(
+            compression=True, compression_format="cheese", archive_dir="craZyNaME"
+        )
+        config.save(filename)
+
+        assert Config.load(filename) == config

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -4,16 +4,25 @@
 #  proj
 #
 
+import os
 from os import path
 import tempfile
+import shutil
 
 from proj import fs
 
 
 class TestFs:
-    def setup_class(cls):
-        cls.base = tempfile.mkdtemp()
-        cls.current = path.join(cls.base, "current")
+    def setup_method(self):
+        self.old_cwd = os.getcwd()
+        self.base = tempfile.mkdtemp()
+        self.current = path.join(self.base, "current")
+        fs.mkdir(self.current)
+        os.chdir(self.current)
+
+    def teardown_method(self):
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.base)
 
     def test_mkdir(self):
         dest = path.join(self.current, "dog")
@@ -25,3 +34,9 @@ class TestFs:
         assert not path.isdir(dest2)
         fs.mkdir(dest2)
         assert path.isdir(dest2)
+
+    def test_iter_single_file(self):
+        filename = "example.out"
+        fs.touch(filename)
+
+        assert list(fs.iter_files(filename)) == [filename]

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+#  test_fs.py
+#  proj
+#
+
+from os import path
+import tempfile
+
+from proj import fs
+
+
+class TestFs:
+    def setup_class(cls):
+        cls.base = tempfile.mkdtemp()
+        cls.current = path.join(cls.base, "current")
+
+    def test_mkdir(self):
+        dest = path.join(self.current, "dog")
+        assert not path.isdir(dest)
+        fs.mkdir(dest)
+        assert path.isdir(dest)
+
+        dest2 = path.join(self.current, "mouse", "a", "b", "c")
+        assert not path.isdir(dest2)
+        fs.mkdir(dest2)
+        assert path.isdir(dest2)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+#
+#  test_logic.py
+#  proj
+#
+
+import os
+from os import path
+import tempfile
+import shutil
+import time
+import math
+from typing import Optional
+import random
+import string
+
+import arrow
+import pytest
+
+from proj import logic, fs, configfile
+
+
+def test_first_quarter_start():
+    a = arrow.get(2000, 1, 1)
+    assert logic._to_quarter(a) == ("2000", "q1")
+
+
+def test_first_quarter_end():
+    a = arrow.get(2000, 3, 1)
+    assert logic._to_quarter(a) == ("2000", "q1")
+
+
+def test_last_quarter_start():
+    a = arrow.get(2000, 10, 1)
+    assert logic._to_quarter(a) == ("2000", "q4")
+
+
+def test_last_quarter_end():
+    a = arrow.get(2000, 12, 1)
+    assert logic._to_quarter(a) == ("2000", "q4")
+
+
+class TestMainLogic:
+    def setup_method(self):
+        self.base = tempfile.mkdtemp()
+
+        self.archive = path.join(self.base, "archive")
+        fs.mkdir(self.archive)
+
+        self.current = path.join(self.base, "current")
+        fs.mkdir(self.current)
+
+        self.old_cwd = os.getcwd()
+        os.chdir(self.current)
+
+        self.no_compression = configfile.Config(
+            archive_dir=self.archive, compression=False, compression_format=None
+        )
+        self.bz2_compression = configfile.Config(
+            archive_dir=self.archive, compression=True, compression_format="bztar"
+        )
+
+    def teardown_method(self):
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.base)
+
+    def test_time_conversion(self):
+        # we should be able to convert from a timestamp and back
+        t = time.time()
+        a = arrow.get(t)
+        assert math.floor(t) == pytest.approx(a.timestamp)
+
+    def test_latest_check_for_single_file(self):
+        a = random_time()
+        proj_name, proj_path = self.make_proj(a=a)
+        assert path.isdir(proj_path)
+        assert fs.last_modified(proj_path) == a
+
+    def test_list_empty(self):
+        projects = logic.list_projects([], self.no_compression)
+        assert projects == []
+
+    def test_list_empty_with_glob(self):
+        projects = logic.list_projects(["a", "b", "c"], self.no_compression)
+        assert projects == []
+
+    def test_archive_project_in_current_dir_by_name_uncompressed(self):
+        a = arrow.get(2000, 1, 1)
+        proj_name, proj_path = self.make_proj(a=a)
+
+        logic.archive(proj_name, self.no_compression)
+
+        expected_loc = path.join(self.archive, "2000", "q1", proj_name)
+        assert path.isdir(expected_loc)
+        assert path.exists(path.join(expected_loc, "data"))
+
+    def test_archive_project_in_current_dir_by_name_compressed(self):
+        a = arrow.get(2000, 1, 1)
+        proj_name, proj_path = self.make_proj(a=a)
+
+        logic.archive(proj_name, self.bz2_compression)
+
+        expected_loc = path.join(self.archive, "2000", "q1", proj_name + ".tar.bz2")
+        assert path.exists(expected_loc)
+
+    def test_archive_project_by_full_path_compressed(self):
+        a = arrow.get(2000, 1, 1)
+        proj_name, proj_path = self.make_proj(a=a)
+
+        logic.archive(proj_path, self.bz2_compression)
+
+        expected_loc = path.join(self.archive, "2000", "q1", f"{proj_name}.tar.bz2")
+        assert path.exists(expected_loc)
+
+    def test_archive_project_by_full_path_uncompressed(self):
+        a = arrow.get(2000, 1, 1)
+        proj_name, proj_path = self.make_proj(a=a)
+
+        logic.archive(proj_path, self.no_compression)
+
+        expected_loc = path.join(self.archive, "2000", "q1", proj_name)
+        assert path.isdir(expected_loc)
+        assert path.exists(path.join(expected_loc, "data"))
+
+    def test_list_projects(self):
+        # archive a project
+        a = arrow.get(2000, 1, 1)
+        proj_name, proj_path = self.make_proj(a=a)
+
+        logic.archive(proj_name, self.no_compression)
+
+        expected = [path.join("2000", "q1", proj_name)]
+
+        # list it
+        projects = logic.list_projects([], self.no_compression)
+        assert projects == expected
+
+        # list it by prefix
+        prefix = proj_name[:4]
+        projects = logic.list_projects([prefix], self.no_compression)
+        assert projects == expected
+
+    def test_archive_and_restore(self):
+        # make a project
+        proj_name, proj_path = self.make_proj()
+
+        # archive it
+        logic.archive(proj_name, self.no_compression)
+        assert not path.isdir(proj_path)
+
+        # restore it
+        logic.restore(proj_name, self.no_compression)
+        assert path.isdir(proj_path)
+
+    def test_archive_dir_doesnt_exist(self):
+        config = configfile.Config(archive_dir="/tmp/does-not-exist")
+        logic.list_projects([], config)
+
+    def test_archive_nonexistent_folder(self):
+        with pytest.raises(logic.CommandError):
+            logic.archive("old-buddy-fred", self.no_compression)
+
+    def test_archive_empty_folder(self):
+        proj_path = path.join(self.current, "empty")
+        os.mkdir(proj_path)
+        with pytest.raises(logic.CommandError):
+            logic.archive(proj_path, self.no_compression)
+
+    def test_restore_missing_project(self):
+        with pytest.raises(logic.CommandError):
+            logic.restore("my-dignity", self.no_compression)
+
+    def test_restore_onto_existing_dir(self):
+        # make a project
+        proj_name, proj_path = self.make_proj()
+
+        # archive it
+        logic.archive(proj_name, self.no_compression)
+        assert not path.isdir(proj_path)
+
+        # put something else in the way
+        os.mkdir(proj_name)
+
+        with pytest.raises(logic.CommandError):
+            logic.restore(proj_name, self.no_compression)
+
+    def test_restore_the_most_recent_of_duplicates(self):
+        name = random_string(8)
+
+        self.make_proj(name=name, a=arrow.get(2020, 1, 1), data="newer")
+        logic.archive(name, self.no_compression)
+
+        self.make_proj(name=name, a=arrow.get(2000, 1, 1), data="older")
+        logic.archive(name, self.no_compression)
+
+        logic.restore(name, self.no_compression)
+        with open(path.join(name, "data")) as istream:
+            data = istream.read()
+        assert data == "newer"
+
+    def make_proj(
+        self,
+        name: Optional[str] = None,
+        a: Optional[arrow.Arrow] = None,
+        data: str = "",
+    ):
+        a = a or random_time()
+        t = a.timestamp
+
+        proj_name = name or random_string(8)
+        proj_path = path.join(self.current, proj_name)
+
+        os.mkdir(proj_path)
+
+        # make an empty file at proj/data
+        f = path.join(proj_path, "data")
+        with open(f, "w") as ostream:
+            ostream.write(data)
+
+        # set its modification time
+        os.utime(f, (t, t))
+
+        return proj_name, proj_path
+
+
+def random_time():
+    return arrow.get(math.floor(random.random() * arrow.get(2038, 1, 1).timestamp))
+
+
+def random_string(length):
+    return "".join(random.choice(string.ascii_lowercase) for i in range(length))

--- a/tests/test_proj.py
+++ b/tests/test_proj.py
@@ -71,7 +71,19 @@ class TestProj(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, "")
 
-    def test_archive_project_in_current_dir_by_name(self):
+    def test_archive_project_in_current_dir_by_name_uncompressed(self):
+        a = arrow.get(2000, 1, 1)
+        proj_name, proj_path = self.make_proj(a=a)
+
+        with chdir(self.current):
+            result = self.runner.invoke(proj.archive, ["--no-compress", proj_name])
+            self.assertEqual(result.exit_code, 0)
+
+        expected_loc = path.join(self.archive, "2000", "q1", proj_name)
+        assert path.isdir(expected_loc)
+        assert path.exists(path.join(expected_loc, "data"))
+
+    def test_archive_project_in_current_dir_by_name_compressed(self):
         a = arrow.get(2000, 1, 1)
         proj_name, proj_path = self.make_proj(a=a)
 
@@ -79,15 +91,28 @@ class TestProj(unittest.TestCase):
             result = self.runner.invoke(proj.archive, [proj_name])
             self.assertEqual(result.exit_code, 0)
 
-        expected_loc = path.join(self.archive, "2000", "q1", proj_name)
-        assert path.isdir(expected_loc)
-        assert path.exists(path.join(expected_loc, "data"))
+        expected_loc = path.join(
+            self.archive, "2000", "q1", proj_name + proj.COMPRESS_EXT
+        )
+        assert path.exists(expected_loc)
 
-    def test_archive_project_by_full_path(self):
+    def test_archive_project_by_full_path_compressed(self):
         a = arrow.get(2000, 1, 1)
         proj_name, proj_path = self.make_proj(a=a)
 
         result = self.runner.invoke(proj.archive, [proj_path])
+        self.assertEqual(result.exit_code, 0)
+
+        expected_loc = path.join(
+            self.archive, "2000", "q1", proj_name + proj.COMPRESS_EXT
+        )
+        assert path.exists(expected_loc)
+
+    def test_archive_project_by_full_path_uncompressed(self):
+        a = arrow.get(2000, 1, 1)
+        proj_name, proj_path = self.make_proj(a=a)
+
+        result = self.runner.invoke(proj.archive, ["--no-compress", proj_path])
         self.assertEqual(result.exit_code, 0)
 
         expected_loc = path.join(self.archive, "2000", "q1", proj_name)


### PR DESCRIPTION
In order to enable optional compression:

- Move from environment variable to config file at `~/.proj.yml`
- Support archiving to specified compression format
- Support restoring from any supported format
- Refactor for better test coverage